### PR TITLE
Fix issues with image path generation

### DIFF
--- a/classes/Dataset.php
+++ b/classes/Dataset.php
@@ -661,10 +661,8 @@ class Dataset {
      */
     public function getIconOptions() {
         $icon = $this->getIcon(); // icon options as provided by user
-        $route = Utils::ICON_ROUTE;
-        // necessary to generate top-level folder of the site (i.e. where the pages, user, etc. folders are contained) and place it in front of the url - otherwise url will not work for tours that are not top-level
-        $page = Grav::instance()['page'];
-        $full_route = str_replace($page->route(), '', $page->url()) . '/' . Utils::ICON_ROUTE;
+        $route = Utils::ICON_ROUTE; // route for checking if file exists
+        $full_route = Utils::getRoot() . "/$route"; // route for accessing file from frontend
         $defaults = []; // fallback values for invalid/null values in icon, needs to be set
         $options = []; // icon options to return
         // determine correct defaults to use and set icon url

--- a/classes/Dataset.php
+++ b/classes/Dataset.php
@@ -662,12 +662,15 @@ class Dataset {
     public function getIconOptions() {
         $icon = $this->getIcon(); // icon options as provided by user
         $route = Utils::ICON_ROUTE;
+        // necessary to generate top-level folder of the site (i.e. where the pages, user, etc. folders are contained) and place it in front of the url - otherwise url will not work for tours that are not top-level
+        $page = Grav::instance()['page'];
+        $full_route = str_replace($page->route(), '', $page->url()) . '/' . Utils::ICON_ROUTE;
         $defaults = []; // fallback values for invalid/null values in icon, needs to be set
         $options = []; // icon options to return
         // determine correct defaults to use and set icon url
         if (($file = Utils::getStr($icon, 'file')) && File::instance("$route/$file")->exists()) {
             // valid icon file provided by user
-            $options['iconUrl'] = "$route/$file";
+            $options['iconUrl'] = "$full_route/$file";
             $defaults = self::CUSTOM_MARKER_FALLBACKS;
         } else if ($url = Utils::getStr($icon, 'iconUrl')) {
             // iconUrl set by user
@@ -678,9 +681,9 @@ class Dataset {
             $options['iconUrl'] = $defaults['iconUrl'];
         }
         // retina and shadow urls
-        if (($file = Utils::getStr($icon, 'retina')) && File::instance("$route/$file")->exists()) $options['iconRetinaUrl'] = "$route/$file";
+        if (($file = Utils::getStr($icon, 'retina')) && File::instance("$route/$file")->exists()) $options['iconRetinaUrl'] = "$full_route/$file";
         else if ($url = Utils::getStr($icon, 'iconRetinaUrl') ?: Utils::getStr($defaults, 'iconRetinaUrl')) $options['iconRetinaUrl'] = $url;
-        if (($file = Utils::getStr($icon, 'shadow')) && File::instance("$route/$file")->exists()) $options['shadowUrl'] = "$route/$file";
+        if (($file = Utils::getStr($icon, 'shadow')) && File::instance("$route/$file")->exists()) $options['shadowUrl'] = "$full_route/$file";
         else if ($url = Utils::getStr($icon, 'shadowUrl') ?: Utils::getStr($defaults, 'shadowUrl')) $options['shadowUrl'] = $url;
         // icon size can be set directly, only use if neither height nor width is set
         if (!isset($icon['height']) && !isset($icon['width']) && ($size = Utils::get($icon, 'iconSize')) && is_array($size) && (count($size) === 2) && is_int($size[0]) && is_int($size[1]) && $size[0] >= 0 && $size[1] >= 0) $options['iconSize'] = $size;

--- a/classes/Tour.php
+++ b/classes/Tour.php
@@ -1219,7 +1219,7 @@ class Tour {
                     $info = [
                         'file' => $file,
                         'text' => $text,
-                        'icon' => Utils::BASEMAP_ROUTE,
+                        'icon' => Utils::getRoot() . '/' . Utils::BASEMAP_ROUTE,
                         'class' => 'basemap',
                         'symbol_alt' => Utils::getStr($basemap, 'legend_alt'),
                     ];
@@ -1253,10 +1253,8 @@ class Tour {
      */
     public function getBasemapData() {
         return array_filter(array_map(function($info) {
-            $page = Grav::instance()['page']; // necessary to generate addition to url - providing url starting with user/ does not work when tours are not top level
             if ($bounds = Utils::getBounds(Utils::getArr($info, 'bounds'))) return [
-                // place the top-level folder of the site (i.e. where the pages, user, etc. folders are contained) in front of the url (see note above for $page)
-                'url' => str_replace($page->route(), '', $page->url()) . '/' . Utils::BASEMAP_ROUTE . '/' . $info['file'],
+                'url' => Utils::getRoot() . '/' . Utils::BASEMAP_ROUTE . '/' . $info['file'],
                 'bounds' => Utils::getBounds(Utils::getArr($info, 'bounds')),
                 'options' => [
                     'max_zoom' => Utils::getType($info, 'max_zoom', 'is_int'),

--- a/classes/Tour.php
+++ b/classes/Tour.php
@@ -3,6 +3,7 @@
 namespace Grav\Plugin\LeafletTour;
 
 use Grav\Common\Grav;
+use Grav\Common\Uri;
 use RocketTheme\Toolbox\File\MarkdownFile;
 use RocketTheme\Toolbox\File\File;
 
@@ -1252,8 +1253,10 @@ class Tour {
      */
     public function getBasemapData() {
         return array_filter(array_map(function($info) {
+            $page = Grav::instance()['page']; // necessary to generate addition to url - providing url starting with user/ does not work when tours are not top level
             if ($bounds = Utils::getBounds(Utils::getArr($info, 'bounds'))) return [
-                'url' => Utils::BASEMAP_ROUTE . '/' . $info['file'],
+                // place the top-level folder of the site (i.e. where the pages, user, etc. folders are contained) in front of the url (see note above for $page)
+                'url' => str_replace($page->route(), '', $page->url()) . '/' . Utils::BASEMAP_ROUTE . '/' . $info['file'],
                 'bounds' => Utils::getBounds(Utils::getArr($info, 'bounds')),
                 'options' => [
                     'max_zoom' => Utils::getType($info, 'max_zoom', 'is_int'),

--- a/classes/Utils.php
+++ b/classes/Utils.php
@@ -87,6 +87,18 @@ class Utils {
     }
 
     /**
+     * When generating paths to images from other folders, need to make sure the path is absolute, not relative. Relative paths beginning with 'user/data' will only work when the page in question is a top-level page.
+     * 
+     * @return string '/top-level-folder' or '' (top-level-folder is where the pages, user, etc. folders are contained, assuming they are stored in their own folder)
+     */
+    public static function getRoot() {
+        $page = Grav::instance()['page'];
+        $root = str_replace($page->route(), '', $page->url());
+        if ($root !== '/') return $root;
+        else return '';
+    }
+
+    /**
      * Search a directory recursively for any files that have routes ending with the provided key.
      * - Result includes all files ending with the input key (and nothing else)
      * 


### PR DESCRIPTION
Image paths beginning with 'user/data' only worked for top-level pages. This solution should work for pages at all levels of nesting.